### PR TITLE
fix: production build with CI=true

### DIFF
--- a/src/hooks/usePhotoGallery.ts
+++ b/src/hooks/usePhotoGallery.ts
@@ -11,7 +11,7 @@ export function usePhotoGallery() {
 
   const [photos, setPhotos] = useState<Photo[]>([]);
   const { getPhoto } = useCamera();
-  const { deleteFile, getUri, readFile, writeFile } = useFilesystem();
+  const { deleteFile, readFile, writeFile } = useFilesystem();
   const { get, set } = useStorage();
 
   useEffect(() => {


### PR DESCRIPTION
When building this app in production mode with `process.env.CI = true` build fails due to unused import warning.
So I removed unused `getUri` import from `userPhotoGallery.ts`.